### PR TITLE
remove data tracking from no search results

### DIFF
--- a/primo-explore/custom/01MIT_INST-MIT/js/custom.module.js
+++ b/primo-explore/custom/01MIT_INST-MIT/js/custom.module.js
@@ -18,6 +18,6 @@ app.component("prmBrowseSearchBarAfter", {
     template: '<mit-alert-banner></mit-alert-banner>',
 });
 app.component("prmNoSearchResultAfter", {
-    template: '<mit-no-search-result data-track-content data-content-name="no results"></mit-no-search-result>'
+    template: '<mit-no-search-result></mit-no-search-result>'
 });
 


### PR DESCRIPTION
### Why these changes are being introduced:
* this code was leftover from before we were using matomo tag manager. it is no longer needed
### How this addresses that need:
* removes unneed content tracking code from `no search results` template

