### PR TITLE
Remove hours from ask us text on Primo homepage

### DIFF
--- a/primo-explore/custom/01MIT_INST-MIT/html/homepage/homepage_en.html
+++ b/primo-explore/custom/01MIT_INST-MIT/html/homepage/homepage_en.html
@@ -72,8 +72,7 @@
             </md-card-title>
             <md-card-content>
                 <p>
-                    <a href="https://libraries.mit.edu/ask">Ask us</a>. Live chat is available M-F, 10am-5pm (excluding
-                    holidays), or you can email us any time.
+                    <a href="https://libraries.mit.edu/ask">Ask Us</a> via chat or email.
                 </p>
 
                 <p>Not sure where to start? <a href="https://libraries.mit.edu/consultations">Request a research


### PR DESCRIPTION
### Why these changes are being introduced:
We want to remove the hours from the Ask Us text on the Primo homepage to avoid having to maintain the hours in two places. The hours are already listed on the Ask Us page.

### How this addresses that need:
Remove the hours from the Ask Us text on the Primo homepage.

### Side effects of this change:
None

### Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/ES-3572